### PR TITLE
fix(theme): keep ThemeProvider mounted to restore Radix dropdowns

### DIFF
--- a/web/src/components/theme-provider.tsx
+++ b/web/src/components/theme-provider.tsx
@@ -13,7 +13,9 @@ export function ThemeProvider({
     setMounted(true);
   }, []);
 
-  if (!mounted) return null;
-
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider {...props}>
+      {mounted ? children : null}
+    </NextThemesProvider>
+  );
 }


### PR DESCRIPTION
- Prevent provider unmount during initial render
- Fix ModeToggle dropdown not opening in production
- Preserve next-themes hydration safety