### PR TITLE
refactor(metrics): keep geo fields null and move labeling to frontend

### DIFF
--- a/api/src/repositories/clicks-repository.ts
+++ b/api/src/repositories/clicks-repository.ts
@@ -17,8 +17,8 @@ export interface ClicksByDate {
 export interface MetricsResult {
   clicksByDate: ClicksByDate[];
   topBrowsers: { browser: string; count: number }[];
-  topCountries: { country: string; count: number }[];
-  topCities: { city: string; count: number }[];
+  topCountries: { country: string | null; count: number }[];
+  topCities: { city: string | null; count: number }[];
 }
 
 export interface ClicksRepository {

--- a/api/src/routes/redirect.ts
+++ b/api/src/routes/redirect.ts
@@ -52,25 +52,7 @@ export async function redirectRoutes(app: FastifyInstance) {
       const ip = getPublicClientIp(request);
       const userAgent = request.headers["user-agent"];
 
-      request.log.info(
-        {
-          getClientIpResult: ip,
-          xForwardedFor: request.headers["x-forwarded-for"],
-          xRealIp: request.headers["x-real-ip"],
-          rawRequestIp: request.ip,
-        },
-        "IP resolution before trackClick",
-      );
-
       await service.trackClick(link.id, ip, userAgent);
-
-      request.log.info(
-        {
-          shortCode,
-          ip,
-        },
-        "Click tracked",
-      );
 
       // Redireciona para a URL original
       return reply.redirect(link.originalUrl);

--- a/api/src/utils/aggregate-click-metrics.ts
+++ b/api/src/utils/aggregate-click-metrics.ts
@@ -47,12 +47,18 @@ export function aggregateClickMetrics(
   const countryMap = new Map<string, number>();
 
   clicks.forEach((click) => {
-    const country = click.country || "Não identificado";
-    countryMap.set(country, (countryMap.get(country) ?? 0) + 1);
+    const country = click.country || null;
+    countryMap.set(
+      country ?? "__unknown__",
+      (countryMap.get(country ?? "__unknown__") ?? 0) + 1,
+    );
   });
 
   const topCountries = Array.from(countryMap.entries())
-    .map(([country, count]) => ({ country, count }))
+    .map(([country, count]) => ({
+      country: country === "__unknown__" ? null : country,
+      count,
+    }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
 
@@ -61,12 +67,18 @@ export function aggregateClickMetrics(
   const cityMap = new Map<string, number>();
 
   clicks.forEach((click) => {
-    const city = click.city || "Não identificada";
-    cityMap.set(city, (cityMap.get(city) ?? 0) + 1);
+    const city = click.city || null;
+    cityMap.set(
+      city ?? "__unknown__",
+      (cityMap.get(city ?? "__unknown__") ?? 0) + 1,
+    );
   });
 
   const topCities = Array.from(cityMap.entries())
-    .map(([city, count]) => ({ city, count }))
+    .map(([city, count]) => ({
+      city: city === "__unknown__" ? null : city,
+      count,
+    }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
 


### PR DESCRIPTION
- Stop emitting 'Não identificado' from backend
- Preserve raw geo data in aggregations
- Let frontend handle display normalization